### PR TITLE
[feat][common-messaging] 공통 메시징 모듈 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,182 @@
 # com.first-ticket.common-messaging
+
+Kafka 기반 메시지 발행/소비를 위한 공통 메시징 모듈입니다.  
+Outbox/Inbox 패턴으로 메시지 유실과 중복 처리를 방지합니다.
+
+---
+
+## 📝 버전
+
+| 버전 | 변경 내용 |
+|------|-----------|
+| `0.0.1-SNAPSHOT` | • Outbox/Inbox 패턴 구현<br>• 멱등성 처리 (`@IdempotentConsumer`)<br>• 재시도 스케줄러 (`OutboxRelayScheduler`)<br>• 데이터 정리 스케줄러 (`MessagingCleanupScheduler`) |
+
+---
+
+## 📦 의존성 추가
+
+> 배포 방법 및 의존성 추가는 [common README](https://github.com/first-ticket/common)를 참고해주세요.
+
+```groovy
+implementation 'com.first-ticket:common-messaging:0.0.1-SNAPSHOT'
+```
+
+---
+
+## 🗂️ 패키지 구조
+
+```
+com.firstticket.common.messaging
+├── CommonMessagingAutoConfiguration.java  ← 자동 빈 등록
+├── event
+│   ├── Events.java                        ← 이벤트 발행 정적 유틸
+│   ├── OutboxEvent.java                   ← 발행 이벤트 record
+│   ├── OutboxEventListener.java           ← Outbox 저장 + Kafka 발행
+│   └── OutboxTransactionHandler.java      ← 발행 성공/실패 상태 업데이트
+├── outbox
+│   ├── Outbox.java                        ← Outbox JPA 엔티티
+│   ├── OutboxRepository.java              ← Outbox Repository
+│   └── OutboxStatus.java                  ← PENDING / PUBLISHED / FAILED
+├── inbox
+│   ├── Inbox.java                         ← Inbox JPA 엔티티
+│   └── InboxRepository.java               ← Inbox Repository
+├── annotation
+│   ├── IdempotentConsumer.java            ← 멱등성 어노테이션
+│   └── IdempotentAspect.java              ← AOP 중복 수신 처리
+└── scheduler
+    ├── OutboxRelayScheduler.java          ← PENDING/FAILED 재시도 (10초)
+    └── MessagingCleanupScheduler.java     ← 오래된 데이터 삭제 (매일)
+```
+
+---
+
+## ⚙️ 설정
+
+`application.yml`에 Kafka 설정을 추가합니다.
+
+```yaml
+spring:
+    kafka:
+        # Kafka 브로커 주소 (로컬: localhost:29092, 도커: kafka:9092)
+        bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
+
+        producer:
+            key-serializer: org.apache.kafka.common.serialization.StringSerializer
+            value-serializer: org.apache.kafka.common.serialization.StringSerializer
+            properties:
+                # 프로듀서 레벨 중복 발행 방지
+                enable.idempotence: true
+                # 전송 총 제한 시간 2분 (이 시간 내에서 재시도 반복)
+                delivery.timeout.ms: 120000
+                # delivery.timeout.ms 내에서 사실상 무한 재시도
+                retries: 2147483647
+                # 순서 보장 + 성능 최적화 (idempotence 활성화 시 최대 5)
+                max.in.flight.requests.per.connection: 5
+                # 브로커 연결 대기 최대 시간 10초
+                max.block.ms: 10000
+
+        consumer:
+            # 기본 컨슈머 그룹 ID (서비스명 사용)
+            group-id: ${spring.application.name}
+            # 새로운 그룹이 시작할 때 가장 처음 오프셋부터 읽기
+            auto-offset-reset: earliest
+            # 수동 커밋 사용 (ack-mode: manual_immediate)
+            enable-auto-commit: false
+            key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+            value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+            properties:
+                # 컨슈머가 살아있는지 확인하는 세션 타임아웃 30초
+                session.timeout.ms: 30000
+                # 메시지 처리가 이 시간을 초과하면 그룹에서 제외 (5분)
+                max.poll.interval.ms: 300000
+
+        listener:
+            # acknowledge() 호출 즉시 오프셋 커밋
+            ack-mode: manual_immediate
+
+logging:
+    level:
+        org.apache.kafka.clients.NetworkClient: ERROR
+```
+
+> ⚠️ `.env`에 `KAFKA_BOOTSTRAP_SERVERS`를 반드시 설정해야 합니다.
+> ```
+> # 로컬 개발 환경
+> KAFKA_BOOTSTRAP_SERVERS=localhost:29092
+> 
+> # 도커 환경
+> KAFKA_BOOTSTRAP_SERVERS=kafka:9092
+> ```
+
+`group-id`는 yml에서 설정하거나 `@KafkaListener`에서 직접 지정할 수 있습니다.
+
+---
+
+## 📤 이벤트 발행
+
+`@Transactional` 메서드 안에서 `Events.publish()`를 호출합니다.  
+도메인 트랜잭션이 커밋되기 전에 Outbox에 저장되고, 커밋 후 Kafka로 발행됩니다.
+
+`correlationId`는 동일한 처리 흐름에서 발행되는 이벤트를 식별하는 상관 ID입니다.  
+보통 요청 단위로 생성한 UUID 문자열을 사용합니다. (예: `UUID.randomUUID().toString()`)  
+Zipkin 등 분산 트레이싱 도구와 연동 시 트레이스 ID를 그대로 사용할 수 있습니다.
+
+```java
+@Transactional
+public void createSample(SampleRequest request) {
+    sampleRepository.save(sample);
+
+    Events.publish(
+        UUID.randomUUID().toString(), // correlationId: 요청 단위 상관 ID (추후 Trace-Id로 교체 예정)
+        "SAMPLE",                     // aggregateType
+        sample.getId(),               // aggregateId (UUID)
+        "sample.created",             // eventType (Kafka 토픽명)
+        sampleCreatedPayload          // payload (Object → JSON 직렬화)
+    );
+}
+```
+
+---
+
+## 📥 이벤트 수신
+
+`@IdempotentConsumer`를 붙이면 Inbox 기반 중복 수신이 자동으로 처리됩니다.  
+파라미터는 반드시 `ConsumerRecord<String, String>`을 포함해야 합니다.
+
+```java
+@IdempotentConsumer
+@KafkaListener(topics = "sample.created")
+public void consume(ConsumerRecord<String, String> record, Acknowledgment ack) {
+    SampleCreatedPayload payload = JsonUtil.fromJson(record.value(), SampleCreatedPayload.class);
+    // 비즈니스 로직
+    ack.acknowledge();
+}
+```
+
+---
+
+## ⚠️ 에러 처리 흐름
+
+```
+이벤트 발행
+    │
+    ├─ Outbox 저장 실패  → 트랜잭션 롤백 (500 반환)
+    │
+    └─ Kafka 발행 실패  → FAILED 상태로 변경
+           │
+           └─ 스케줄러 재시도 (10초마다)
+                  │
+                  └─ MAX_RETRY_COUNT(3) 초과 → DLT 토픽으로 이동
+                                               {eventType}.DLT
+```
+
+---
+
+## 🗑️ 데이터 정리
+
+오래된 Outbox/Inbox 데이터는 스케줄러가 자동으로 삭제합니다.
+
+| 대상 | 조건 | 실행 시각 |
+|------|------|---------|
+| Outbox | PUBLISHED 상태 + 7일 경과 | 매일 새벽 3시 |
+| Inbox | 처리 완료 + 7일 경과 | 매일 새벽 4시 |

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,10 @@ repositories {
     }
 }
 
+ext {
+    set('springCloudVersion', "2025.0.2")
+}
+
 dependencies {
     api 'com.first-ticket:common:0.0.2-SNAPSHOT'
     api 'org.springframework.kafka:spring-kafka'
@@ -70,6 +74,12 @@ publishing {
                 password = env['GITHUB_TOKEN']
             }
         }
+    }
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,7 @@ ext {
 dependencies {
     api 'com.first-ticket:common:0.0.2-SNAPSHOT'
     api 'org.springframework.kafka:spring-kafka'
+    api 'org.springframework.boot:spring-boot-starter-aop'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/firstticket/common/messaging/CommonMessagingAutoConfiguration.java
+++ b/src/main/java/com/firstticket/common/messaging/CommonMessagingAutoConfiguration.java
@@ -1,0 +1,61 @@
+package com.firstticket.common.messaging;
+
+import com.firstticket.common.messaging.annotation.IdempotentAspect;
+import com.firstticket.common.messaging.event.Events;
+import com.firstticket.common.messaging.event.OutboxEventListener;
+import com.firstticket.common.messaging.event.OutboxTransactionHandler;
+import com.firstticket.common.messaging.inbox.InboxRepository;
+import com.firstticket.common.messaging.outbox.OutboxRepository;
+import com.firstticket.common.messaging.scheduler.MessagingCleanupScheduler;
+import com.firstticket.common.messaging.scheduler.OutboxRelayScheduler;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@AutoConfiguration
+@EnableScheduling
+@EnableAspectJAutoProxy(proxyTargetClass = true)
+public class CommonMessagingAutoConfiguration {
+
+    @Bean
+    public Events events() {
+        return new Events();
+    }
+
+    @Bean
+    public OutboxTransactionHandler outboxTransactionHandler(
+        OutboxRepository outboxRepository,
+        KafkaTemplate<String, String> kafkaTemplate) {
+        return new OutboxTransactionHandler(outboxRepository, kafkaTemplate);
+    }
+
+    @Bean
+    public OutboxEventListener outboxEventListener(
+        OutboxRepository outboxRepository,
+        KafkaTemplate<String, String> kafkaTemplate,
+        OutboxTransactionHandler outboxTransactionHandler
+    ) {
+        return new OutboxEventListener(outboxRepository, kafkaTemplate, outboxTransactionHandler);
+    }
+
+    @Bean
+    public OutboxRelayScheduler outboxRelayScheduler(
+        OutboxRepository outboxRepository,
+        KafkaTemplate<String, String> kafkaTemplate,
+        OutboxTransactionHandler outboxTransactionHandler) {
+        return new OutboxRelayScheduler(outboxRepository, kafkaTemplate, outboxTransactionHandler);
+    }
+
+    @Bean
+    public IdempotentAspect idempotentAspect(InboxRepository inboxRepository) {
+        return new IdempotentAspect(inboxRepository);
+    }
+
+    @Bean
+    public MessagingCleanupScheduler messagingCleanupScheduler(JPAQueryFactory queryFactory) {
+        return new MessagingCleanupScheduler(queryFactory);
+    }
+}

--- a/src/main/java/com/firstticket/common/messaging/annotation/IdempotentAspect.java
+++ b/src/main/java/com/firstticket/common/messaging/annotation/IdempotentAspect.java
@@ -9,6 +9,7 @@ import org.apache.kafka.common.header.Header;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
@@ -30,17 +31,16 @@ public class IdempotentAspect {
             return joinPoint.proceed();
         }
 
-        if (inboxRepository.existsById(messageId)) {
+        try {
+            inboxRepository.saveAndFlush(Inbox.create(messageId));
+        } catch (DataIntegrityViolationException e) {
             log.warn("[Inbox] 중복 메시지 무시. messageId={}", messageId);
             return null;
         }
 
         try {
             Object result = joinPoint.proceed();
-
-            inboxRepository.save(Inbox.create(messageId));
             log.debug("[Inbox] 메시지 처리 완료. messageId={}", messageId);
-
             return result;
         } catch (Throwable e) {
             log.error("[Inbox] 메시지 처리 실패. messageId={}", messageId, e);

--- a/src/main/java/com/firstticket/common/messaging/annotation/IdempotentAspect.java
+++ b/src/main/java/com/firstticket/common/messaging/annotation/IdempotentAspect.java
@@ -1,0 +1,66 @@
+package com.firstticket.common.messaging.annotation;
+
+import com.firstticket.common.messaging.inbox.Inbox;
+import com.firstticket.common.messaging.inbox.InboxRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Header;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Slf4j
+@Aspect
+@RequiredArgsConstructor
+public class IdempotentAspect {
+
+    private final InboxRepository inboxRepository;
+
+    @Around("@annotation(IdempotentConsumer)")
+    @Transactional(rollbackFor = Exception.class)
+    public Object around(ProceedingJoinPoint joinPoint) throws Throwable {
+        UUID messageId = extractMessageId(joinPoint.getArgs());
+
+        if (messageId == null) {
+            log.warn("[Inbox] messageId를 찾을 수 없습니다. 멱등성 체크 없이 실행합니다.");
+            return joinPoint.proceed();
+        }
+
+        if (inboxRepository.existsById(messageId)) {
+            log.warn("[Inbox] 중복 메시지 무시. messageId={}", messageId);
+            return null;
+        }
+
+        try {
+            Object result = joinPoint.proceed();
+
+            inboxRepository.save(Inbox.create(messageId));
+            log.debug("[Inbox] 메시지 처리 완료. messageId={}", messageId);
+
+            return result;
+        } catch (Throwable e) {
+            log.error("[Inbox] 메시지 처리 실패. messageId={}", messageId, e);
+            throw e;
+        }
+    }
+
+    private UUID extractMessageId(Object[] args) {
+        for (Object arg : args) {
+            if (arg instanceof ConsumerRecord<?, ?> record) {
+                Header header = record.headers().lastHeader("message_id");
+                if (header == null) return null;
+                try {
+                    return UUID.fromString(new String(header.value()));
+                } catch (IllegalArgumentException e) {
+                    log.warn("[Inbox] message_id 헤더가 UUID 형식이 아닙니다. value={}", new String(header.value()));
+                    return null;
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/firstticket/common/messaging/annotation/IdempotentAspect.java
+++ b/src/main/java/com/firstticket/common/messaging/annotation/IdempotentAspect.java
@@ -10,6 +10,7 @@ import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
@@ -25,6 +26,7 @@ public class IdempotentAspect {
     @Transactional(rollbackFor = Exception.class)
     public Object around(ProceedingJoinPoint joinPoint) throws Throwable {
         UUID messageId = extractMessageId(joinPoint.getArgs());
+        Acknowledgment ack = extractAcknowledgement(joinPoint.getArgs());
 
         if (messageId == null) {
             log.warn("[Inbox] messageId를 찾을 수 없습니다. 멱등성 체크 없이 실행합니다.");
@@ -35,6 +37,10 @@ public class IdempotentAspect {
             inboxRepository.saveAndFlush(Inbox.create(messageId));
         } catch (DataIntegrityViolationException e) {
             log.warn("[Inbox] 중복 메시지 무시. messageId={}", messageId);
+            if (ack != null) {
+                // 중복 감지 시 컨슈머 메서드가 실행되지 않으므로 AOP에서 직접 offset 커밋
+                ack.acknowledge();
+            }
             return null;
         }
 
@@ -59,6 +65,15 @@ public class IdempotentAspect {
                     log.warn("[Inbox] message_id 헤더가 UUID 형식이 아닙니다. value={}", new String(header.value()));
                     return null;
                 }
+            }
+        }
+        return null;
+    }
+
+    private Acknowledgment extractAcknowledgement(Object[] args) {
+        for (Object arg : args) {
+            if (arg instanceof Acknowledgment) {
+                return (Acknowledgment) arg;
             }
         }
         return null;

--- a/src/main/java/com/firstticket/common/messaging/annotation/IdempotentConsumer.java
+++ b/src/main/java/com/firstticket/common/messaging/annotation/IdempotentConsumer.java
@@ -1,0 +1,11 @@
+package com.firstticket.common.messaging.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface IdempotentConsumer {
+}

--- a/src/main/java/com/firstticket/common/messaging/event/Events.java
+++ b/src/main/java/com/firstticket/common/messaging/event/Events.java
@@ -1,0 +1,20 @@
+package com.firstticket.common.messaging.event;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.util.UUID;
+
+public class Events {
+
+    private static ApplicationEventPublisher publisher;
+
+    @Autowired
+    public void init(ApplicationEventPublisher publisher) {
+        Events.publisher = publisher;
+    }
+
+    public static void publish(String correlationId, String aggregateType, UUID aggregateId, String eventType, Object payload) {
+        publisher.publishEvent(new OutboxEvent(correlationId, aggregateType, aggregateId, eventType, payload));
+    }
+}

--- a/src/main/java/com/firstticket/common/messaging/event/OutboxEvent.java
+++ b/src/main/java/com/firstticket/common/messaging/event/OutboxEvent.java
@@ -1,0 +1,11 @@
+package com.firstticket.common.messaging.event;
+
+import java.util.UUID;
+
+public record OutboxEvent(
+    String correlationId,
+    String aggregateType,
+    UUID aggregateId,
+    String eventType,
+    Object payload
+) {}

--- a/src/main/java/com/firstticket/common/messaging/event/OutboxEventListener.java
+++ b/src/main/java/com/firstticket/common/messaging/event/OutboxEventListener.java
@@ -1,0 +1,69 @@
+package com.firstticket.common.messaging.event;
+
+import com.firstticket.common.json.JsonUtil;
+import com.firstticket.common.messaging.outbox.Outbox;
+import com.firstticket.common.messaging.outbox.OutboxRepository;
+import com.firstticket.common.messaging.outbox.OutboxStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.springframework.context.event.EventListener;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@RequiredArgsConstructor
+public class OutboxEventListener {
+
+    private final OutboxRepository outboxRepository;
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final OutboxTransactionHandler outboxTransactionHandler;
+
+    @EventListener
+    @Transactional(propagation = Propagation.REQUIRED)
+    public void saveOutbox(OutboxEvent event) {
+
+        if (outboxRepository.existsByCorrelationIdAndEventType(event.correlationId(), event.eventType())) {
+            log.warn("[Outbox] 중복 이벤트 무시. eventType={}, correlationId={}", event.eventType(), event.correlationId());
+            return;
+        }
+
+        String payload = JsonUtil.toJson(event.payload());
+        outboxRepository.saveAndFlush(Outbox.create(
+            event.correlationId(),
+            event.aggregateType(),
+            event.aggregateId(),
+            event.eventType(),
+            payload
+        ));
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+    public void publish(OutboxEvent event) {
+        outboxRepository.findByCorrelationIdAndEventType(event.correlationId(), event.eventType())
+            .filter(outbox -> outbox.getStatus() == OutboxStatus.PENDING)
+            .ifPresent(outbox -> {
+                ProducerRecord<String, String> record = new ProducerRecord<>(
+                    outbox.getEventType(),
+                    outbox.getAggregateId().toString(),
+                    outbox.getPayload()
+                );
+                record.headers().add("message_id", outbox.getId().toString().getBytes());
+
+                try {
+                    kafkaTemplate.send(record)
+                        .whenComplete((result, e) -> {
+                            if (e == null) outboxTransactionHandler.success(event.correlationId(), event.eventType());
+                            else outboxTransactionHandler.failure(event.correlationId(), event.eventType(), outbox.getPayload());
+                        });
+                } catch (Exception e) {
+                    outboxTransactionHandler.failure(event.correlationId(), event.eventType(), outbox.getPayload());
+                }
+
+            });
+    }
+
+}

--- a/src/main/java/com/firstticket/common/messaging/event/OutboxTransactionHandler.java
+++ b/src/main/java/com/firstticket/common/messaging/event/OutboxTransactionHandler.java
@@ -1,0 +1,56 @@
+package com.firstticket.common.messaging.event;
+
+import com.firstticket.common.messaging.outbox.OutboxRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+public class OutboxTransactionHandler {
+
+    private final OutboxRepository outboxRepository;
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    private static final int MAX_RETRY_COUNT = 3;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void success(String correlationId, String eventType) {
+        outboxRepository.findByCorrelationIdAndEventType(correlationId, eventType)
+            .ifPresent(outbox -> {
+                outbox.markPublished();
+                log.info("[Outbox] 발행 완료. eventType={}, correlationId={}", eventType, correlationId);
+            });
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void failure(String correlationId, String eventType, String payload) {
+        outboxRepository.findByCorrelationIdAndEventType(correlationId, eventType)
+            .ifPresent(outbox -> {
+                outbox.markFailed();
+                outboxRepository.saveAndFlush(outbox);
+
+                if (outbox.getRetryCount() >= MAX_RETRY_COUNT) {
+                    log.error("[Outbox] 최대 재시도 초과. DLT로 이동. eventType={}, correlationId={}", eventType, correlationId);
+                    sendToDlt(correlationId, eventType, payload);
+                } else {
+                    log.warn("[Outbox] 발행 실패. ({}/{}). eventType={}, correlationId={}", outbox.getRetryCount(), MAX_RETRY_COUNT, eventType, correlationId);
+                }
+            });
+    }
+
+    private void sendToDlt(String correlationId, String eventType, String payload) {
+        String dltTopic = eventType + ".DLT";
+        try {
+            kafkaTemplate.send(dltTopic, correlationId, payload)
+                .whenComplete((result, e) -> {
+                    if (e != null) log.error("[Outbox] DLT 전송 실패. eventType={}, correlationId={}", eventType, correlationId, e);
+                    else log.info("[Outbox] DLT 전송 완료. eventType={}, correlationId={}", eventType, correlationId);
+                });
+        } catch (Exception e) {
+            log.error("[Outbox] DLT 전송 중 예외 발생. eventType={}, correlationId={}", eventType, correlationId, e);
+        }
+    }
+}

--- a/src/main/java/com/firstticket/common/messaging/inbox/Inbox.java
+++ b/src/main/java/com/firstticket/common/messaging/inbox/Inbox.java
@@ -1,0 +1,34 @@
+package com.firstticket.common.messaging.inbox;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "P_INBOX")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Inbox {
+
+    @Id
+    @Column(name = "message_id")
+    private UUID id;
+
+    @Column(name = "processed_at")
+    private LocalDateTime processedAt;
+
+    public static Inbox create(UUID id) {
+        return new Inbox(id, LocalDateTime.now());
+    }
+}

--- a/src/main/java/com/firstticket/common/messaging/inbox/InboxRepository.java
+++ b/src/main/java/com/firstticket/common/messaging/inbox/InboxRepository.java
@@ -5,6 +5,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.UUID;
 
 public interface InboxRepository extends JpaRepository<Inbox, UUID> {
-
-    boolean existsById(UUID id);
 }

--- a/src/main/java/com/firstticket/common/messaging/inbox/InboxRepository.java
+++ b/src/main/java/com/firstticket/common/messaging/inbox/InboxRepository.java
@@ -1,0 +1,10 @@
+package com.firstticket.common.messaging.inbox;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface InboxRepository extends JpaRepository<Inbox, UUID> {
+
+    boolean existsById(UUID id);
+}

--- a/src/main/java/com/firstticket/common/messaging/outbox/Outbox.java
+++ b/src/main/java/com/firstticket/common/messaging/outbox/Outbox.java
@@ -1,0 +1,89 @@
+package com.firstticket.common.messaging.outbox;
+
+import com.firstticket.common.persistence.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "P_OUTBOX", uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"correlation_id", "event_type"})
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Outbox extends BaseEntity {
+
+    @Id
+    @Column(nullable = false, updatable = false)
+    private UUID id;
+
+    @Column(name = "correlation_id", nullable = false)
+    private String correlationId;
+
+    @Column(name = "aggregate_type", nullable = false, length = 50)
+    private String aggregateType;
+
+    @Column(name = "aggregate_id", nullable = false)
+    private UUID aggregateId;
+
+    @Column(name = "event_type", nullable = false, length = 50)
+    private String eventType;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    private String payload;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private OutboxStatus status;
+
+    @Column(name = "published_at", nullable = true)
+    private LocalDateTime publishedAt;
+
+    @Column(name = "retry_count", nullable = false)
+    private int retryCount;
+
+    public static Outbox create(
+        String correlationId,
+        String aggregateType,
+        UUID aggregateId,
+        String eventType,
+        String payload
+    ) {
+        return new Outbox(
+            UUID.randomUUID(),
+            correlationId,
+            aggregateType,
+            aggregateId,
+            eventType,
+            payload,
+            OutboxStatus.PENDING,
+            null,
+            0
+        );
+    }
+
+    public void markPublished() {
+        this.status = OutboxStatus.PUBLISHED;
+        this.publishedAt = LocalDateTime.now();
+    }
+
+    public void markFailed() {
+        this.status = OutboxStatus.FAILED;
+        this.retryCount++;
+    }
+
+}

--- a/src/main/java/com/firstticket/common/messaging/outbox/OutboxRepository.java
+++ b/src/main/java/com/firstticket/common/messaging/outbox/OutboxRepository.java
@@ -1,0 +1,16 @@
+package com.firstticket.common.messaging.outbox;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface OutboxRepository extends JpaRepository<Outbox, UUID> {
+
+    List<Outbox> findByStatus(OutboxStatus status);
+
+    Optional<Outbox> findByCorrelationIdAndEventType(String correlationId, String eventType);
+
+    boolean existsByCorrelationIdAndEventType(String correlationId, String eventType);
+}

--- a/src/main/java/com/firstticket/common/messaging/outbox/OutboxRepository.java
+++ b/src/main/java/com/firstticket/common/messaging/outbox/OutboxRepository.java
@@ -8,9 +8,9 @@ import java.util.UUID;
 
 public interface OutboxRepository extends JpaRepository<Outbox, UUID> {
 
-    List<Outbox> findByStatus(OutboxStatus status);
-
     Optional<Outbox> findByCorrelationIdAndEventType(String correlationId, String eventType);
 
     boolean existsByCorrelationIdAndEventType(String correlationId, String eventType);
+
+    List<Outbox> findByStatusInAndRetryCountLessThan(List<OutboxStatus> statuses, int retryCount);
 }

--- a/src/main/java/com/firstticket/common/messaging/outbox/OutboxStatus.java
+++ b/src/main/java/com/firstticket/common/messaging/outbox/OutboxStatus.java
@@ -1,0 +1,7 @@
+package com.firstticket.common.messaging.outbox;
+
+public enum OutboxStatus {
+    PENDING,
+    PUBLISHED,
+    FAILED
+}

--- a/src/main/java/com/firstticket/common/messaging/scheduler/MessagingCleanupScheduler.java
+++ b/src/main/java/com/firstticket/common/messaging/scheduler/MessagingCleanupScheduler.java
@@ -1,0 +1,40 @@
+package com.firstticket.common.messaging.scheduler;
+
+import com.firstticket.common.messaging.inbox.QInbox;
+import com.firstticket.common.messaging.outbox.OutboxStatus;
+import com.firstticket.common.messaging.outbox.QOutbox;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@RequiredArgsConstructor
+public class MessagingCleanupScheduler {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Transactional
+    @Scheduled(cron = "0 0 3 * * *")
+    public void cleanupOutbox() {
+        long deleted = queryFactory
+            .delete(QOutbox.outbox)
+            .where(QOutbox.outbox.status.eq(OutboxStatus.PUBLISHED)
+                .and(QOutbox.outbox.publishedAt.before(LocalDateTime.now().minusWeeks(1L))))
+            .execute();
+        log.info("[Outbox] {}건 삭제 완료", deleted);
+    }
+
+    @Transactional
+    @Scheduled(cron = "0 0 4 * * *")
+    public void cleanupInbox() {
+        long deleted = queryFactory
+            .delete(QInbox.inbox)
+            .where(QInbox.inbox.processedAt.before(LocalDateTime.now().minusWeeks(1L)))
+            .execute();
+        log.info("[Inbox] {}건 삭제 완료", deleted);
+    }
+}

--- a/src/main/java/com/firstticket/common/messaging/scheduler/OutboxRelayScheduler.java
+++ b/src/main/java/com/firstticket/common/messaging/scheduler/OutboxRelayScheduler.java
@@ -1,0 +1,56 @@
+package com.firstticket.common.messaging.scheduler;
+
+import com.firstticket.common.messaging.event.OutboxTransactionHandler;
+import com.firstticket.common.messaging.outbox.Outbox;
+import com.firstticket.common.messaging.outbox.OutboxRepository;
+import com.firstticket.common.messaging.outbox.OutboxStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+public class OutboxRelayScheduler {
+
+    private final OutboxRepository outboxRepository;
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final OutboxTransactionHandler outboxTransactionHandler;
+
+    private static final int MAX_RETRY_COUNT = 3;
+
+    @Scheduled(fixedDelay = 10000)
+    public void relay() {
+        List<Outbox> targets = outboxRepository.findByStatusInAndRetryCountLessThan(
+            List.of(OutboxStatus.PENDING, OutboxStatus.FAILED),
+            MAX_RETRY_COUNT
+        );
+
+        if (targets.isEmpty()) return;
+
+        log.info("[OutboxScheduler] 재전송 대상 {}건 처리 시작", targets.size());
+
+        for (Outbox outbox : targets) {
+            try {
+                ProducerRecord<String, String> record = new ProducerRecord<>(
+                    outbox.getEventType(),
+                    outbox.getAggregateId().toString(),
+                    outbox.getPayload()
+                );
+                record.headers().add("message_id", outbox.getId().toString().getBytes());
+
+                kafkaTemplate.send(record)
+                    .whenComplete((result, e) -> {
+                        if (e == null) outboxTransactionHandler.success(outbox.getCorrelationId(), outbox.getEventType());
+                        else outboxTransactionHandler.failure(outbox.getCorrelationId(), outbox.getEventType(), outbox.getPayload());
+                    });
+            } catch (Exception e) {
+                log.error("[OutboxScheduler] 재전송 중 예외 발생. correlationId={}", outbox.getCorrelationId(), e);
+                outboxTransactionHandler.failure(outbox.getCorrelationId(), outbox.getEventType(), outbox.getPayload());
+            }
+        }
+    }
+}

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.firstticket.common.messaging.CommonMessagingAutoConfiguration


### PR DESCRIPTION
## 🌱 설명
<!-- 
    태그와 Assign 활용을 생활화합시다!
-->

- Kafka 기반 메시지 발행/소비 공통 모듈 구현
- Outbox/Inbox 패턴으로 메시지 유실 및 중복 처리 방지


## 📌 관련 이슈
- close #1 


## 💻 커밋 유형
> 해당하는 항목에 `x`를 채워주세요.
- [x] feat     : 새로운 기능 추가
- [ ] fix      : 버그 수정 (긴급 핫픽스 포함)
- [ ] refactor : 리팩토링
- [x] chore    : 빌드 설정, 의존성 업데이트 등
- [x] docs     : 문서 수정
- [ ] comment  : 주석 추가 및 변경
- [ ] rename   : 파일 / 폴더 이동 또는 이름 변경
- [ ] remove   : 파일 삭제
- [ ] test     : 테스트 코드 추가 / 수정


## 📝 체크리스트
> PR 올리기 전에 아래 항목을 확인해주세요.
- [ ] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 설명이 필요한 부분 / 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [ ] 기존 테스트와 충돌하지 않음을 확인했나요?


## 📚 추가 설명
<!--
  타 서비스에 영향을 주는 변경이라면 반드시 여기에 명시해주세요.
  예) 이 PR은 Booking 서비스의 예매 확정 이벤트 구조를 변경합니다.
      → Payment, Notification 담당자 확인 필요
-->
### 전체 흐름

```
이벤트 발행
    │
    ├─ Outbox 저장 실패 → 트랜잭션 롤백 (500 반환)
    │
    └─ Kafka 발행 실패 → FAILED 상태로 변경
           │
           └─ 스케줄러 재시도 (10초마다)
                  │
                  └─ MAX_RETRY_COUNT(3) 초과 → DLT 토픽으로 이동
```

### 사용 방법

**이벤트 발행**
```java
@Transactional
public void createSample(SampleRequest request) {
    sampleRepository.save(sample);
    Events.publish(
        UUID.randomUUID().toString(), // 추후 Trace-Id 추가시 Trace-Id로 주입
        "SAMPLE",
        sample.getId(),
        "sample.created",
        sampleCreatedPayload
    );
}
```

**이벤트 수신**
```java
@IdempotentConsumer
@KafkaListener(topics = "sample.created")
public void consume(ConsumerRecord<String, String> record, Acknowledgment ack) {
    SampleCreatedPayload payload = JsonUtil.fromJson(record.value(), SampleCreatedPayload.class);
    ack.acknowledge();
}
```

### 서비스에서 추가해야 할 설정
`application.yml`에 Kafka 설정이 필요합니다. 자세한 내용은 [common-messaging README](https://github.com/first-ticket/common-messaging)를 참고해주세요.


---

<!-- 
  ✅ 리뷰어 가이드 (이 섹션은 리뷰어에게만 보입니다 — 머지 전 삭제 불필요)
  
  리뷰할 때 아래 관점을 참고해주세요.
  
  [1] 도메인 로직 위치
      비즈니스 규칙이 Service가 아닌 Entity / VO / Enum 안에 있는지 확인해주세요.
      (Fat Service 안티패턴 방지)

  [2] 서비스 간 영향 범위
      Kafka 이벤트 구조, API 계약(Request/Response), X-User-Id 헤더 의존 등
      타 서비스에 영향을 주는 변경이 있다면 반드시 코멘트로 남겨주세요.

  [3] 예외 처리
      경계값, 동시성, 트랜잭션 롤백 시나리오가 처리되어 있는지 확인해주세요.

  [4] 리뷰 코멘트 규칙
      - 반드시 수정 : [must] 태그 사용   예) [must] 이 로직은 도메인으로 이동해야 합니다.
      - 제안 / 질문 : [nit] 태그 사용    예) [nit] 이렇게 바꾸면 어떨까요?
      nit(nitpick)은 "사소한 지적"을 의미하며,
      머지를 블로킹하지 않는 선택적 개선 제안을 뜻합니다.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 멱등성 메시지 소비자 지원으로 중복 처리 방지
  * 아웃박스 패턴 기반 안정적 메시지 전송 및 재시도, 실패 시 DLT 자동 라우팅
  * 정기적 아웃박스/인박스 정리 및 아웃박스 재전송 스케줄러 추가
  * Spring Boot 자동설정 등록 및 Spring Cloud/AOP 기반 메시징 인프라 활성화
  * 이벤트 발행용 공개 API(Events.publish) 추가

* **문서**
  * 모듈 사용법, 설정 예시 및 동작 설명을 포함한 README 대폭 확장
<!-- end of auto-generated comment: release notes by coderabbit.ai -->