### PR TITLE
[fix][common-messaging] 메시지 중복 수신 시 DataIntegrityViolationException이 발생하지 않는 버그 수정

### DIFF
--- a/src/main/java/com/firstticket/common/messaging/inbox/Inbox.java
+++ b/src/main/java/com/firstticket/common/messaging/inbox/Inbox.java
@@ -15,6 +15,11 @@ import org.springframework.data.domain.Persistable;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+/**
+ * Inbox는 append-only 엔티티입니다.
+ * 한 번 저장된 후에는 절대 재저장되지 않아야 합니다.
+ * 재저장 경로가 생길 경우, isNew()를 @PostLoad와 함께 실제 상태를 반영하도록 변경해야 합니다.
+ */
 @Entity
 @Table(name = "P_INBOX")
 @Getter

--- a/src/main/java/com/firstticket/common/messaging/inbox/Inbox.java
+++ b/src/main/java/com/firstticket/common/messaging/inbox/Inbox.java
@@ -10,6 +10,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Persistable;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -19,7 +20,7 @@ import java.util.UUID;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class Inbox {
+public class Inbox implements Persistable<UUID> {
 
     @Id
     @Column(name = "message_id")
@@ -30,5 +31,10 @@ public class Inbox {
 
     public static Inbox create(UUID id) {
         return new Inbox(id, LocalDateTime.now());
+    }
+
+    @Override
+    public boolean isNew() {
+        return true;
     }
 }


### PR DESCRIPTION
## 🌱 설명
<!-- 
    태그와 Assign 활용을 생활화합시다!
-->

- `Inbox` 엔티티에 `Persistable<UUID>` 구현하여 중복 수신 시 `DataIntegrityViolationException`이 발생하지 않던 버그 수정


## 📌 관련 이슈
> 이 PR과 연관된 이슈 번호를 작성해주세요. (이슈 없으면 생략 가능)
- close #7


## 💻 커밋 유형
> 해당하는 항목에 `x`를 채워주세요.
- [ ] feat     : 새로운 기능 추가
- [x] fix      : 버그 수정 (긴급 핫픽스 포함)
- [ ] refactor : 리팩토링
- [ ] chore    : 빌드 설정, 의존성 업데이트 등
- [ ] docs     : 문서 수정
- [ ] comment  : 주석 추가 및 변경
- [ ] rename   : 파일 / 폴더 이동 또는 이름 변경
- [ ] remove   : 파일 삭제
- [ ] test     : 테스트 코드 추가 / 수정


## 📝 체크리스트
> PR 올리기 전에 아래 항목을 확인해주세요.
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 설명이 필요한 부분 / 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?


## 📚 추가 설명
<!--
  타 서비스에 영향을 주는 변경이라면 반드시 여기에 명시해주세요.
  예) 이 PR은 Booking 서비스의 예매 확정 이벤트 구조를 변경합니다.
      → Payment, Notification 담당자 확인 필요
-->
- `@GeneratedValue` 없이 `@Id`를 직접 할당하는 엔티티는 JPA `save()` 호출 시 SELECT 후 이미 존재하면 INSERT 대신 UPDATE를 시도한다. `Persistable.isNew()`가 항상 `true`를 반환하도록 하면 SELECT 없이 바로 INSERT를 시도하므로 PK 제약 위반 예외가 정상 발생한다.

- 별도의 버전 변경은 없으니 머지 후 각 서비스에서 아래 명령어만 실행하시면 됩니다
  ```
  ./gradlew --refresh-dependencies
  ```

---

<!-- 
  ✅ 리뷰어 가이드 (이 섹션은 리뷰어에게만 보입니다 — 머지 전 삭제 불필요)
  
  리뷰할 때 아래 관점을 참고해주세요.
  
  [1] 도메인 로직 위치
      비즈니스 규칙이 Service가 아닌 Entity / VO / Enum 안에 있는지 확인해주세요.
      (Fat Service 안티패턴 방지)

  [2] 서비스 간 영향 범위
      Kafka 이벤트 구조, API 계약(Request/Response), X-User-Id 헤더 의존 등
      타 서비스에 영향을 주는 변경이 있다면 반드시 코멘트로 남겨주세요.

  [3] 예외 처리
      경계값, 동시성, 트랜잭션 롤백 시나리오가 처리되어 있는지 확인해주세요.

  [4] 리뷰 코멘트 규칙
      - 반드시 수정 : [must] 태그 사용   예) [must] 이 로직은 도메인으로 이동해야 합니다.
      - 제안 / 질문 : [nit] 태그 사용    예) [nit] 이렇게 바꾸면 어떨까요?
      nit(nitpick)은 "사소한 지적"을 의미하며,
      머지를 블로킹하지 않는 선택적 개선 제안을 뜻합니다.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **리팩터링**
  * 받은편지함 엔티티의 저장 처리 방식이 변경되어, 저장 시 항목이 항상 신규로 간주되어 기존 항목을 덮어쓰지 않고 append(추가) 형태로 처리됩니다.
  * 향후 재저장(재동일성) 경로가 도입될 경우 동작 조정이 필요할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->