### PR TITLE
[refactor][common-messaging] common-messaging Outbox/Inbox 선택적 활성화 지원

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Outbox/Inbox 패턴으로 메시지 유실과 중복 처리를 방지합니다.
 | 버전 | 변경 내용 |
 |------|-----------|
 | `0.0.1-SNAPSHOT` | • Outbox/Inbox 패턴 구현<br>• 멱등성 처리 (`@IdempotentConsumer`)<br>• 재시도 스케줄러 (`OutboxRelayScheduler`)<br>• 데이터 정리 스케줄러 (`MessagingCleanupScheduler`) |
+| `0.0.2-SNAPSHOT` | • Outbox/Inbox 선택적 활성화 지원 (`messaging.outbox.enabled`, `messaging.inbox.enabled`)<br>• `MessagingCleanupScheduler` → `OutboxCleanupScheduler` / `InboxCleanupScheduler` 분리<br>• `OutboxRelayScheduler` 활성화 조건에 `messaging.outbox.enabled` 추가 |
 
 ---
 
@@ -18,7 +19,7 @@ Outbox/Inbox 패턴으로 메시지 유실과 중복 처리를 방지합니다.
 > 배포 방법 및 의존성 추가는 [common README](https://github.com/first-ticket/common)를 참고해주세요.
 
 ```groovy
-implementation 'com.first-ticket:common-messaging:0.0.1-SNAPSHOT'
+implementation 'com.first-ticket:common-messaging:0.0.2-SNAPSHOT'
 ```
 
 ---
@@ -45,12 +46,90 @@ com.firstticket.common.messaging
 │   └── IdempotentAspect.java              ← AOP 중복 수신 처리
 └── scheduler
     ├── OutboxRelayScheduler.java          ← PENDING/FAILED 재시도 (10초)
-    └── MessagingCleanupScheduler.java     ← 오래된 데이터 삭제 (매일)
+    ├── OutboxCleanupScheduler.java        ← Outbox 오래된 데이터 삭제 (매일)
+    └── InboxCleanupScheduler.java         ← Inbox 오래된 데이터 삭제 (매일)
 ```
 
 ---
 
 ## ⚙️ 설정
+
+### Outbox/Inbox 활성화
+
+Outbox/Inbox는 기본적으로 비활성화 상태입니다. 사용하는 서비스에서 명시적으로 활성화해야 합니다.
+
+| 설정 키 | 기본값 | 설명 |
+|---------|--------|------|
+| `messaging.outbox.enabled` | `false` | Outbox 관련 빈 활성화 여부 |
+| `messaging.inbox.enabled` | `false` | Inbox 관련 빈 활성화 여부 |
+
+```yaml
+# Outbox만 사용하는 서비스
+messaging:
+  outbox:
+    enabled: true
+
+# Inbox만 사용하는 서비스
+messaging:
+  inbox:
+    enabled: true
+
+# 둘 다 사용하는 서비스
+messaging:
+  outbox:
+    enabled: true
+  inbox:
+    enabled: true
+```
+
+<br>
+
+⚠️ Outbox 또는 Inbox를 활성화하는 경우 각 서비스 `Application` 클래스에서 해당 패키지를 `@EntityScan`, `@EnableJpaRepositories`에 명시해야 합니다.
+
+- Outbox만 사용하는 서비스
+    ```java
+    @SpringBootApplication
+    @EntityScan(basePackages = {
+        "com.firstticket.sampleservice",           // 각 서비스 스캔 범위
+        "com.firstticket.common.messaging.outbox"  // Outbox
+    })
+    @EnableJpaRepositories(basePackages = {
+        "com.firstticket.sampleservice",
+        "com.firstticket.common.messaging.outbox"
+    })
+    public class SampleServiceApplication { ... }
+    ```
+
+- Inbox만 사용하는 서비스
+    ```java
+    @SpringBootApplication
+    @EntityScan(basePackages = {
+        "com.firstticket.sampleservice",          // 각 서비스 스캔 범위
+        "com.firstticket.common.messaging.inbox"  // Inbox
+    })
+    @EnableJpaRepositories(basePackages = {
+        "com.firstticket.sampleservice",
+        "com.firstticket.common.messaging.inbox"
+    })
+    public class SampleServiceApplication { ... }
+    ```
+
+- 둘 다 사용하는 서비스
+    ```java
+    @SpringBootApplication
+    @EntityScan(basePackages = {
+        "com.firstticket.sampleservice",    // 각 서비스 스캔 범위
+        "com.firstticket.common.messaging"  // Outbox + Inbox
+    })
+    @EnableJpaRepositories(basePackages = {
+        "com.firstticket.sampleservice",
+        "com.firstticket.common.messaging"
+    })
+    public class SampleServiceApplication { ... }
+    ```
+
+
+### Kafka 설정
 
 `application.yml`에 Kafka 설정을 추가합니다.
 
@@ -103,7 +182,7 @@ logging:
 > ```
 > # 로컬 개발 환경
 > KAFKA_BOOTSTRAP_SERVERS=localhost:29092
-> 
+>
 > # 도커 환경
 > KAFKA_BOOTSTRAP_SERVERS=kafka:9092
 > ```
@@ -176,25 +255,27 @@ public void consume(ConsumerRecord<String, String> record, Acknowledgment ack) {
 
 아웃박스 스케줄러의 활성화 여부와 실행 주기를 외부 설정으로 제어할 수 있습니다.
 
-| 설정 키 | 기본값     | 설명 |
-|---------|---------|------|
-| `common.messaging.scheduler.enabled` | `true`  | 스케줄러 활성화 여부 |
-| `common.messaging.scheduler.delay` | `10000` | 스케줄러 실행 주기 (ms) |
+| 설정 키 | 기본값 | 설명 |
+|---------|--------|------|
+| `messaging.outbox.scheduler.enabled` | `true` | 스케줄러 활성화 여부 |
+| `messaging.outbox.scheduler.delay` | `10000` | 스케줄러 실행 주기 (ms) |
+> 아웃박스 스케줄러는 `messaging.outbox.enabled: true` 일 때만 작동하므로 Outbox 미사용 시 별도 설정 불필요
 
 ```yaml
-# 로컬 개발환경에서 스케줄러 비활성화 예시
-common:
-  messaging:
+# 로컬 환경에서 스케줄러 로그 비활성화
+messaging:
+  outbox:
+    enabled: true
     scheduler:
       enabled: false
 
-# 스케줄러 활성화는 하고 실행 주기만 설정하는 경우
-common:
-  messaging:
+# 스케줄러 실행 주기 변경
+messaging:
+  outbox:
+    enabled: true
     scheduler:
       enabled: true
       delay: 60000 # 1분
-
 ```
 
 > - `enabled: false` 시 스케줄러 빈이 등록되지 않아 SELECT 쿼리가 실행되지 않습니다.

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'com.first-ticket'
-version = '0.0.1-SNAPSHOT'
+version = '0.0.2-SNAPSHOT'
 description = 'common-messaging'
 
 java {
@@ -36,10 +36,15 @@ repositories {
     mavenCentral()
     maven {
         name = 'GitHubPackages'
-        url = 'https://maven.pkg.github.com/first-ticket/*'
-        mavenContent {
-            includeGroup 'com.first-ticket'
+        url = 'https://maven.pkg.github.com/first-ticket/common'
+        credentials {
+            username = env['GITHUB_USER']
+            password = env['GITHUB_TOKEN']
         }
+    }
+    maven {
+        name = 'GitHubPackages'
+        url = 'https://maven.pkg.github.com/first-ticket/common-jpa'
         credentials {
             username = env['GITHUB_USER']
             password = env['GITHUB_TOKEN']
@@ -52,8 +57,8 @@ ext {
 }
 
 dependencies {
-    api 'com.first-ticket:common:0.0.3-SNAPSHOT'
-    api 'com.first-ticket:common-jpa:0.0.1-SNAPSHOT'
+    api 'com.first-ticket:common:0.0.4-SNAPSHOT'
+    api 'com.first-ticket:common-jpa:0.0.2-SNAPSHOT'
     api 'org.springframework.kafka:spring-kafka'
     api 'org.springframework.boot:spring-boot-starter-aop'
 

--- a/src/main/java/com/firstticket/common/messaging/CommonMessagingAutoConfiguration.java
+++ b/src/main/java/com/firstticket/common/messaging/CommonMessagingAutoConfiguration.java
@@ -6,10 +6,12 @@ import com.firstticket.common.messaging.event.OutboxEventListener;
 import com.firstticket.common.messaging.event.OutboxTransactionHandler;
 import com.firstticket.common.messaging.inbox.InboxRepository;
 import com.firstticket.common.messaging.outbox.OutboxRepository;
-import com.firstticket.common.messaging.scheduler.MessagingCleanupScheduler;
+import com.firstticket.common.messaging.scheduler.InboxCleanupScheduler;
+import com.firstticket.common.messaging.scheduler.OutboxCleanupScheduler;
 import com.firstticket.common.messaging.scheduler.OutboxRelayScheduler;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperties;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
@@ -43,7 +45,10 @@ public class CommonMessagingAutoConfiguration {
     }
 
     @Bean
-    @ConditionalOnProperty(value = "common.messaging.scheduler.enabled", havingValue = "true", matchIfMissing = true)
+    @ConditionalOnProperties({
+        @ConditionalOnProperty(name = "messaging.outbox.enabled", havingValue = "true", matchIfMissing = false),
+        @ConditionalOnProperty(name = "messaging.outbox.scheduler.enabled", havingValue = "true", matchIfMissing = true)
+    })
     public OutboxRelayScheduler outboxRelayScheduler(
         OutboxRepository outboxRepository,
         KafkaTemplate<String, String> kafkaTemplate,
@@ -57,7 +62,14 @@ public class CommonMessagingAutoConfiguration {
     }
 
     @Bean
-    public MessagingCleanupScheduler messagingCleanupScheduler(JPAQueryFactory queryFactory) {
-        return new MessagingCleanupScheduler(queryFactory);
+    @ConditionalOnProperty(name = "messaging.outbox.enabled", havingValue = "true", matchIfMissing = false)
+    public OutboxCleanupScheduler outboxCleanupScheduler(JPAQueryFactory queryFactory) {
+        return new OutboxCleanupScheduler(queryFactory);
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "messaging.inbox.enabled", havingValue = "true", matchIfMissing = false)
+    public InboxCleanupScheduler inboxCleanupScheduler(JPAQueryFactory queryFactory) {
+        return new InboxCleanupScheduler(queryFactory);
     }
 }

--- a/src/main/java/com/firstticket/common/messaging/scheduler/InboxCleanupScheduler.java
+++ b/src/main/java/com/firstticket/common/messaging/scheduler/InboxCleanupScheduler.java
@@ -13,20 +13,9 @@ import java.time.LocalDateTime;
 
 @Slf4j
 @RequiredArgsConstructor
-public class MessagingCleanupScheduler {
+public class InboxCleanupScheduler {
 
     private final JPAQueryFactory queryFactory;
-
-    @Transactional
-    @Scheduled(cron = "0 0 3 * * *")
-    public void cleanupOutbox() {
-        long deleted = queryFactory
-            .delete(QOutbox.outbox)
-            .where(QOutbox.outbox.status.eq(OutboxStatus.PUBLISHED)
-                .and(QOutbox.outbox.publishedAt.before(LocalDateTime.now().minusWeeks(1L))))
-            .execute();
-        log.info("[Outbox] {}건 삭제 완료", deleted);
-    }
 
     @Transactional
     @Scheduled(cron = "0 0 4 * * *")

--- a/src/main/java/com/firstticket/common/messaging/scheduler/OutboxCleanupScheduler.java
+++ b/src/main/java/com/firstticket/common/messaging/scheduler/OutboxCleanupScheduler.java
@@ -1,0 +1,31 @@
+package com.firstticket.common.messaging.scheduler;
+
+import com.firstticket.common.messaging.inbox.QInbox;
+import com.firstticket.common.messaging.outbox.OutboxStatus;
+import com.firstticket.common.messaging.outbox.QOutbox;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@RequiredArgsConstructor
+public class OutboxCleanupScheduler {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Transactional
+    @Scheduled(cron = "0 0 3 * * *")
+    public void cleanupOutbox() {
+        long deleted = queryFactory
+            .delete(QOutbox.outbox)
+            .where(QOutbox.outbox.status.eq(OutboxStatus.PUBLISHED)
+                .and(QOutbox.outbox.publishedAt.before(LocalDateTime.now().minusWeeks(1L))))
+            .execute();
+        log.info("[Outbox] {}건 삭제 완료", deleted);
+    }
+
+}


### PR DESCRIPTION
## 🌱 설명
<!-- 
    태그와 Assign 활용을 생활화합시다!
-->
- Outbox/Inbox 선택적 활성화 지원 (`messaging.outbox.enabled`, `messaging.inbox.enabled`)
- `MessagingCleanupScheduler` → `OutboxCleanupScheduler` / `InboxCleanupScheduler` 분리
- `OutboxRelayScheduler` 활성화 조건에 `messaging.outbox.enabled` 추가
- 버전 업데이트: `0.0.1-SNAPSHOT` → `0.0.2-SNAPSHOT`


## 📌 관련 이슈
- close #9


## 💻 커밋 유형
> 해당하는 항목에 `x`를 채워주세요.
- [ ] feat     : 새로운 기능 추가
- [ ] fix      : 버그 수정 (긴급 핫픽스 포함)
- [x] refactor : 리팩토링
- [x] chore    : 빌드 설정, 의존성 업데이트 등
- [x] docs     : 문서 수정
- [ ] comment  : 주석 추가 및 변경
- [ ] rename   : 파일 / 폴더 이동 또는 이름 변경
- [ ] remove   : 파일 삭제
- [ ] test     : 테스트 코드 추가 / 수정


## 📝 체크리스트
> PR 올리기 전에 아래 항목을 확인해주세요.
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 설명이 필요한 부분 / 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?


## 📚 추가 설명
<!--
  타 서비스에 영향을 주는 변경이라면 반드시 여기에 명시해주세요.
  예) 이 PR은 Booking 서비스의 예매 확정 이벤트 구조를 변경합니다.
      → Payment, Notification 담당자 확인 필요
-->
- Outbox/Inbox 기본값은 비활성화입니다.
- Outbox 또는 Inbox 활성화 시 각 서비스에 `@EntityScan`, `@EnableJpaRepositories` 설정이 필요합니다.
- 자세한 내용은 [common-messaging README](https://github.com/first-ticket/common-messaging)를 참고해주세요.

---

<!-- 
  ✅ 리뷰어 가이드 (이 섹션은 리뷰어에게만 보입니다 — 머지 전 삭제 불필요)
  
  리뷰할 때 아래 관점을 참고해주세요.
  
  [1] 도메인 로직 위치
      비즈니스 규칙이 Service가 아닌 Entity / VO / Enum 안에 있는지 확인해주세요.
      (Fat Service 안티패턴 방지)

  [2] 서비스 간 영향 범위
      Kafka 이벤트 구조, API 계약(Request/Response), X-User-Id 헤더 의존 등
      타 서비스에 영향을 주는 변경이 있다면 반드시 코멘트로 남겨주세요.

  [3] 예외 처리
      경계값, 동시성, 트랜잭션 롤백 시나리오가 처리되어 있는지 확인해주세요.

  [4] 리뷰 코멘트 규칙
      - 반드시 수정 : [must] 태그 사용   예) [must] 이 로직은 도메인으로 이동해야 합니다.
      - 제안 / 질문 : [nit] 태그 사용    예) [nit] 이렇게 바꾸면 어떨까요?
      nit(nitpick)은 "사소한 지적"을 의미하며,
      머지를 블로킹하지 않는 선택적 개선 제안을 뜻합니다.
-->